### PR TITLE
Add Wikipedia translation helper

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -60,17 +60,25 @@
         chrome.storage.local.set({ chatgptJS_textsToTranslate: texts }, () => {
             window.open('https://chatgpt.com/?translate_page=1', '_blank');
         });
-        const checkInterval = setInterval(() => {
-            chrome.storage.local.get('chatgptJS_translatedTexts', ({ chatgptJS_translatedTexts }) => {
+        let timeoutId;
+        function handleStorageChange(changes, area) {
+            if (area === 'local' && changes.chatgptJS_translatedTexts) {
+                const chatgptJS_translatedTexts = changes.chatgptJS_translatedTexts.newValue;
                 if (Array.isArray(chatgptJS_translatedTexts)) {
                     paragraphs.forEach((p, i) => {
                         if (chatgptJS_translatedTexts[i]) p.innerText = chatgptJS_translatedTexts[i];
                     });
                     chrome.storage.local.remove(['chatgptJS_textsToTranslate', 'chatgptJS_translatedTexts']);
-                    clearInterval(checkInterval);
+                    chrome.storage.onChanged.removeListener(handleStorageChange);
+                    if (timeoutId) clearTimeout(timeoutId);
                 }
-            });
-        }, 1000);
+            }
+        }
+        chrome.storage.onChanged.addListener(handleStorageChange);
+        // Fallback: remove listener after 30 seconds if translation doesn't arrive
+        timeoutId = setTimeout(() => {
+            chrome.storage.onChanged.removeListener(handleStorageChange);
+        }, 30000);
     }
 
     // Define FEEDBACK functions

--- a/extension/content.js
+++ b/extension/content.js
@@ -33,12 +33,45 @@
                     settings.save('skipAlert', !config.skipAlert); }
     );}});
 
-    // Your code here...
-    // Your code here...
-    // Your code here...
-    // Your code here...
-    // Your code here...
-    // Your code here...
+    if (location.hostname.endsWith('.wikipedia.org')
+        && !location.hostname.startsWith('en.')) {
+        translateWikipediaPage();
+    }
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('translate_page') === '1') {
+        chrome.storage.local.get('chatgptJS_textsToTranslate', async ({ chatgptJS_textsToTranslate }) => {
+            if (Array.isArray(chatgptJS_textsToTranslate)) {
+                const results = [];
+                for (const text of chatgptJS_textsToTranslate) {
+                    const english = await chatgpt.translate(text, 'English');
+                    results.push(english);
+                }
+                chrome.storage.local.set({ chatgptJS_translatedTexts: results }, () => {
+                    window.close();
+                });
+            } else window.close();
+        });
+    }
+
+    async function translateWikipediaPage() {
+        const paragraphs = Array.from(document.querySelectorAll('p'));
+        const texts = paragraphs.map(p => p.innerText.trim());
+        chrome.storage.local.set({ chatgptJS_textsToTranslate: texts }, () => {
+            window.open('https://chatgpt.com/?translate_page=1', '_blank');
+        });
+        const checkInterval = setInterval(() => {
+            chrome.storage.local.get('chatgptJS_translatedTexts', ({ chatgptJS_translatedTexts }) => {
+                if (Array.isArray(chatgptJS_translatedTexts)) {
+                    paragraphs.forEach((p, i) => {
+                        if (chatgptJS_translatedTexts[i]) p.innerText = chatgptJS_translatedTexts[i];
+                    });
+                    chrome.storage.local.remove(['chatgptJS_textsToTranslate', 'chatgptJS_translatedTexts']);
+                    clearInterval(checkInterval);
+                }
+            });
+        }, 1000);
+    }
 
     // Define FEEDBACK functions
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -17,7 +17,11 @@
         "resources": ["lib/settings-utils.js", "lib/chatgpt.js"]
     }],
     "content_scripts": [{
-        "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
+        "matches": [
+            "https://chatgpt.com/*",
+            "https://chat.openai.com/*",
+            "https://*.wikipedia.org/*"
+        ],
         "js": ["content.js"]
     }],
     "background": { "service_worker": "background.js" }


### PR DESCRIPTION
## Summary
- allow extension to run on wikipedia.org pages
- implement Wikipedia page translation using ChatGPT

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684637359e38832f9edffd2a9ac5d1ac

## Summary by Sourcery

Enable translation of non-English Wikipedia pages using ChatGPT by extracting page content, opening a translation helper tab, and replacing paragraphs with their English translations.

New Features:
- Match the extension on all wikipedia.org pages to activate translation features.
- Extract and store article paragraphs, open a ChatGPT helper tab for translation, and asynchronously replace the page content with translated text.